### PR TITLE
[fix] Etiqueta formulario exportacion censo.

### DIFF
--- a/decide/census/forms.py
+++ b/decide/census/forms.py
@@ -11,4 +11,4 @@ class AtributosUser(forms.Form):
             atributes_list.append((counter, atribute))
             counter += 1
 
-    user_atributes = forms.MultipleChoiceField(label="Selecciona los atributos ", choices=atributes_list, widget=forms.CheckboxSelectMultiple)
+    user_atributes = forms.MultipleChoiceField(label="", choices=atributes_list, widget=forms.CheckboxSelectMultiple)

--- a/decide/census/templates/export_census.html
+++ b/decide/census/templates/export_census.html
@@ -15,6 +15,7 @@
                <div class="col-md-8">
                     <h1>{% trans "vName" %}: {{voting.name}} </h1>
                     <h3>{% trans "vDesc" %}: {{ voting.desc }}</h3>
+                    <p class="mt-5">Selecciona los atributos:</p>
                     <form id="formulario" method="post" action=''>{% csrf_token %}
                          <fieldset>
                                {{formulario}}

--- a/decide/census/tests.py
+++ b/decide/census/tests.py
@@ -105,4 +105,4 @@ class ExportCensusTestCase(BaseTestCase):
         for atribute in selected_atributes:
             voter_data.append(str(voter[atribute]))
         voters_data.append(voter_data)
-        self.assertEquals(voters_data, data[2]) # atribures values
+        self.assertEquals(voters_data, data[2]) # atributes values


### PR DESCRIPTION
Se ha separado la etiqueta del formulario, para que se vea en el html.