### PR TITLE
[DESARROLLO] Actualizada traducción de census

### DIFF
--- a/decide/census/locale/es_ES/LC_MESSAGES/django.po
+++ b/decide/census/locale/es_ES/LC_MESSAGES/django.po
@@ -60,6 +60,10 @@ msgstr "Apellido"
 msgid "voter_id"
 msgstr "ID del votannte"
 
+# Errors
+
+msgid "goBack"
+msgstr "Volver a la lista de votaciones"
 
 
 


### PR DESCRIPTION
Se ha añadido la traducción de una etiqueta de error, referenciada en https://github.com/Villanueva-del-Trabuco-EGC/decide-part-1/issues/1#issuecomment-1336148010


