### PR TITLE
[Fix] Arreglada traducción duplicada

### DIFF
--- a/decide/visualizer/locale/es_ES/LC_MESSAGES/django.po
+++ b/decide/visualizer/locale/es_ES/LC_MESSAGES/django.po
@@ -56,9 +56,6 @@ msgstr "Opción"
 msgid "points"
 msgstr "Puntuación"
 
-msgid "preference"
-msgstr "Preferences"
-
 msgid "votes"
 msgstr "Votos"
 


### PR DESCRIPTION
Existia una traduccion duplicada de visualizer, con errores de compilación