### PR TITLE
[FIX] Fallo en traducción de booth

### DIFF
--- a/decide/booth/locale/es_ES/LC_MESSAGES/django.po
+++ b/decide/booth/locale/es_ES/LC_MESSAGES/django.po
@@ -46,10 +46,10 @@ msgstr "Error"
 msgid "Conglatulations. Your vote has been sent"
 msgstr "¡Enhorabuena! Tu voto se ha enviado"
 
-msgid "registered_as_1"
+msgid "register_as_1"
 msgstr "Registrado en "
 
-msgid "registered_as_2"
+msgid "register_as_2"
 msgstr " como "
 
 msgid "vote_with"


### PR DESCRIPTION
Se ha arreglado typo que impedia traducir.
Fixes Villanueva-del-Trabuco-EGC/decide#31